### PR TITLE
Handle the encoding of the file contents in the caller.

### DIFF
--- a/astropy/setup_helpers.py
+++ b/astropy/setup_helpers.py
@@ -12,6 +12,8 @@ def write_if_different(filename, data):
     Write *data* to *filename*, if the content of the file is
     different.
     """
+    assert isinstance(data, bytes)
+
     if os.path.exists(filename):
         with open(filename, 'rb') as fd:
             original_data = fd.read()
@@ -20,7 +22,7 @@ def write_if_different(filename, data):
 
     if original_data != data:
         with open(filename, 'wb') as fd:
-            fd.write(data.encode('utf-8'))
+            fd.write(data)
 
 
 def check_numpy():

--- a/astropy/wcs/setup_package.py
+++ b/astropy/wcs/setup_package.py
@@ -79,7 +79,7 @@ def write_wcsconfig_h():
     """.format(WCSVERSION, determine_64_bit_int()))
     setup_helpers.write_if_different(
         join(WCSROOT, 'src', 'wcsconfig.h'),
-        h_file.getvalue())
+        h_file.getvalue().encode('ascii'))
 
 ######################################################################
 # GENERATE DOCSTRINGS IN C
@@ -117,7 +117,7 @@ void fill_docstrings(void);
     h_file.write("\n#endif\n\n")
 
     setup_helpers.write_if_different(
-        join(WCSROOT, 'src', 'docstrings.h'), h_file.getvalue())
+        join(WCSROOT, 'src', 'docstrings.h'), h_file.getvalue().encode('utf-8'))
 
     c_file = StringIO()
     c_file.write("""/*
@@ -161,7 +161,7 @@ MSVC, do not support string literals greater than 256 characters.
     c_file.write("#endif\n")
 
     setup_helpers.write_if_different(
-        join(WCSROOT, 'src', 'docstrings.c'), c_file.getvalue())
+        join(WCSROOT, 'src', 'docstrings.c'), c_file.getvalue().encode('utf-8'))
 
 
 def get_extensions(build_type='release'):


### PR DESCRIPTION
Encoding of strings should not be handled in write_if_different, which can not know the encoding.
