### PR TITLE
updates for config/data plans

### DIFF
--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -178,25 +178,34 @@ The result is::
 Working with data files
 -----------------------
 
-Tests that need to make use of a data file should use the
-``get_local_test_data`` and ``get_remote_test_data`` functions, and test files
-should be requested using filenames in the first case, and MD5 hashes in the
-second. Each of these functions returns the local path to the file (and in the
-case of remote data, it is the path to the downloaded file):
+Tests that need to make use of a data file should use the 
+`~astropy.config.data.get_data_fileobj` or 
+`~astropy.config.data.get_data_filename` functions.  These functions search 
+locally first, and then on the astropy data server or an arbitrary URL, and 
+return a file-like object or a local filename, respectively.  They automatically
+cache the data locally if remote data is obtained, and from then on the local 
+copy will be used transparently.
 
-.. warning:: This is going to change
+They also support the use of an MD5 hash to get a specific version of a data
+file.  This hash can be obtained prior to submitting a file to the astropy
+data server by using the `~astropy.config.data.compute_hash` function on a 
+local copy of the file.
 
+Examples
+^^^^^^^^
 ::
 
-    from astropy.util.testing import get_local_test_data, \
-                                     get_remote_test_data
+    from astropy.config import get_data_filename
 
     def test_1():
-        datafile = get_local_test_data('filename.fits')
+        #if filename.fits is a local file in the source distribution
+        datafile = get_data_filename('filename.fits') 
         # do the test
 
     def test_2():
-        datafile = get_remote_test_data('94935ac31d585f68041c08f87d1a19d4')
+        #this is the hash for a particular version of a file stored on the 
+        #astropy data server.
+        datafile = get_data_filename('hash/94935ac31d585f68041c08f87d1a19d4')
         # do the test
 
 The ``get_remote_test_data`` will place the files in a temporary directory


### PR DESCRIPTION
This pull request updates the testing guidelines for the syntax planned for the astropy.config.data module (see e.g. eteq/astropy@126f67a9dfcef5c0f5573d6de10ae57eea6dfcc8).  After this I think the guidelines are ready to merge?
