### PR TITLE
Adjust version-checking to switch to builtin if version is wrong

### DIFF
--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -28,7 +28,7 @@ try:
        version.LooseVersion('2.2.0'):
        
         msg = ("py.test 2.2.0 or later is required, but version {0} found." +
-               " Falling back on py.test budled with astropy.")
+               " Falling back on py.test bundled with astropy.")
         warn(VersionWarning(msg.format(pytest.__version__)))
         raise ImportError(msg.format(pytest.__version__))
 


### PR DESCRIPTION
This implements the idea I mentioned in astropy/astropy#76 - it seems to run the tests just fine, and I'm on py.test 2.1...
