### PR TITLE
Follow on to #425.

### DIFF
--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -156,6 +156,16 @@ class BaseInputter(object):
 
             lines = table.splitlines()
 
+            # FIXME: This is a workaround for the fact that a
+            # bz2.BZ2File can not be wrapped in a io.TextIOWrapper.
+            # On Python 3, we expect to get back unicode strings from
+            # the file object, so here we have to manually decode.
+            if sys.version_info[0] >= 3:
+                import locale
+                if isinstance(lines[0], bytes):
+                    lines = [
+                        x.decode(locale.getpreferredencoding()) for x in lines]
+
         except TypeError:
             try:
                 # See if table supports indexing, slicing, and iteration

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -173,7 +173,7 @@ def test_from_string():
 
 def test_from_filelike():
     f = 't/simple.txt'
-    table = open(f)
+    table = open(f, 'rb')
     testfile = get_testfiles(f)
     data = asciitable.read(table, **testfile['opts'])
     assert_equal(data.dtype.names, testfile['cols'])

--- a/astropy/io/vo/tests/vo_test.py
+++ b/astropy/io/vo/tests/vo_test.py
@@ -791,3 +791,15 @@ def _run_test_from_scratch_example():
     table.array[1] = ('test2.xml', [[0.5, 0.3], [0.2, 0.1]])
 
     assert table.array[0][0] == 'test1.xml'
+
+
+def test_fileobj():
+    # Assert that what we get back is a raw C file pointer
+    # so it will be super fast in the C extension.
+    from ....utils.xml import iterparser
+    filename = get_data_filename('data/regression.xml')
+    with iterparser._convert_to_fd_or_read_function(filename) as fd:
+        if sys.version_info[0] >= 3:
+            assert isinstance(fd, io.FileIO)
+        else:
+            assert isinstance(fd, file)

--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import
 
 import collections
 import functools
+import io
 import sys
 import textwrap
 import warnings
@@ -18,19 +19,32 @@ __all__ = ['find_current_module', 'fnpickle', 'fnunpickle', 'isiterable',
 
 
 @contextlib.contextmanager
-def get_fileobj(name_or_obj):
+def get_fileobj(name_or_obj, binary=False):
     """
-    Given a filename or a file object, return a file object.
+    Given a filename or a readable file-like object, return a readable
+    file-like object.
 
-    This supports passing filenames, URLs, and file objects, any of which can
-    be compressed in gzip or bzip2.
+    This supports passing filenames, URLs, and readable file-like
+    objects, any of which can be compressed in gzip or bzip2.
 
     Parameters
     ----------
-    name_or_obj : str or file-like
-        The filename of the file to access (if given as a string), or the file
-        object to access.
+    name_or_obj : str or file-like object
+        The filename of the file to access (if given as a string), or
+        the file-like object to access.
+
+        If a file-like object, it must be opened in binary mode.
+
+    binary : bool, optional
+        When `False` (default), returns a file-like object that on
+        Python 2.x reads `bytes` objects and on Python 3.x reads `str`
+        (unicode) objects.  This matches the default behavior of
+        `open` when no `mode` argument is provided.
+
+        When `True`, returns a file-like object that will read `bytes`
+        objects.
     """
+    close_fds = []
 
     # Get a file object to the content
     if isinstance(name_or_obj, basestring):
@@ -38,8 +52,13 @@ def get_fileobj(name_or_obj):
         if re.match('(http|https|ftp)://.*', name_or_obj):
             import urllib
             fileobj = urllib.urlopen(name_or_obj)
+            close_fds.append(fileobj)
         else:
-            fileobj = open(name_or_obj, 'rb')
+            if sys.version_info[0] >= 3:
+                fileobj = io.FileIO(name_or_obj, 'r')
+            else:
+                fileobj = open(name_or_obj, 'rb')
+            close_fds.append(fileobj)
     else:
         fileobj = name_or_obj
 
@@ -53,17 +72,17 @@ def get_fileobj(name_or_obj):
     signature = fileobj.read(4)
     fileobj.seek(0)
 
-    if signature[:3] == '\x1f\x8b\x08':  # gzip
+    if signature[:3] == b'\x1f\x8b\x08':  # gzip
         try:
-            import gzip
-            fileobj_new = gzip.GzipFile(fileobj=fileobj, mode='r')
+            from .compat import gzip
+            fileobj_new = gzip.GzipFile(fileobj=fileobj, mode='rb')
             fileobj_new.read(1)  # need to check that the file is really gzip
         except IOError:  # invalid gzip file
             fileobj.seek(0)
         else:
             fileobj_new.seek(0)
             fileobj = fileobj_new
-    elif signature[:3] == 'BZh':  # bzip2
+    elif signature[:3] == b'BZh':  # bzip2
         try:
             # bz2.BZ2File does not support file objects, only filenames, so we
             # need to write the data to a temporary file
@@ -71,8 +90,9 @@ def get_fileobj(name_or_obj):
             tmp = tempfile.NamedTemporaryFile()
             tmp.write(fileobj.read())
             tmp.flush()
+            close_fds.append(tmp)
             import bz2
-            fileobj_new = bz2.BZ2File(tmp.name, mode='r')
+            fileobj_new = bz2.BZ2File(tmp.name, mode='rb')
             fileobj_new.read(1)  # need to check that the file is really bzip2
         except IOError:  # invalid bzip2 file
             fileobj.seek(0)
@@ -80,14 +100,18 @@ def get_fileobj(name_or_obj):
             fileobj_new.seek(0)
             fileobj = fileobj_new
 
+    if sys.version_info[0] >= 3 and not binary:
+        import bz2
+        # FIXME: A bz2.BZ2File can not be wrapped by a TextIOWrapper,
+        # so on Python 3 the user will get back bytes from the file
+        # rather than Unicode as expected.
+        if not isinstance(fileobj, bz2.BZ2File):
+            fileobj = io.TextIOWrapper(fileobj)
+
     yield fileobj
 
-    fileobj.close()
-
-    try:
-        tmp.close()
-    except UnboundLocalError:
-        pass
+    for fd in close_fds:
+        fd.close()
 
 
 def find_current_module(depth=1, finddiff=False):

--- a/astropy/utils/xml/iterparser.py
+++ b/astropy/utils/xml/iterparser.py
@@ -47,20 +47,25 @@ def _convert_to_fd_or_read_function(fd):
        - If it's not a real file object, it's much handier to just
          have a Python function to call.
 
+    This is somewhat quirky behavior, of course, which is why it is
+    private.  For a more useful version of similar behavior, see
+    `astropy.utils.misc.get_fileobj`.
+
     Parameters
     ----------
     fd : object
         May be:
 
-            - a file object, in which case it is returned verbatim.
+            - a file object.  If the file is uncompressed, this raw
+              file object is returned verbatim.  Otherwise, the read
+              method is returned.
 
             - a function that reads from a stream, in which case it is
               returned verbatim.
 
-            - a file path, in which case it is opened.  If it ends in
-              `.gz`, it is assumed to be a gzipped file, and the
-              :meth:`read` method on the file object is returned.
-              Otherwise, the raw file object is returned.
+            - a file path, in which case it is opened.  Again, like a
+              file object, if it's uncompressed, a raw file object is
+              returned, otherwise its read method.
 
             - an object with a :meth:`read` method, in which case that
               method is returned.
@@ -73,50 +78,23 @@ def _convert_to_fd_or_read_function(fd):
     if is_callable(fd):
         yield fd
         return
-    elif isinstance(fd, basestring):
-        if fd.endswith('.gz'):
-            from ...utils.compat import gzip
-            with gzip.GzipFile(fd, 'rb') as real_fd:
-                yield real_fd.read
-                return
+
+    from astropy.utils.misc import get_fileobj
+
+    with get_fileobj(fd, binary=True) as new_fd:
+        if sys.platform.startswith('win'):
+            yield new_fd.read
         else:
-            with open(fd, 'rb') as real_fd:
-                if sys.platform.startswith('win'):
-                    # On Windows, we can't pass a real file descriptor
-                    # to the C level, so we pass the read method
-                    yield real_fd.read
-                    return
-                yield real_fd
-                return
-    elif hasattr(fd, 'read'):
-        assert is_callable(fd.read)
-        magic = fd.read(2)
-        fd.seek(0)
-        if magic == b'\x1f\x8b':
-            from ...utils.compat import gzip
-            fd = gzip.GzipFile(fileobj=fd)
-
-        if type(fd.read(0)) == type(u''):
-            def make_encoder(reader):
-                def read(n):
-                    return reader(n).encode('utf-8')
-            yield make_encoder(fd.read)
-            return
-
-        if not sys.platform.startswith('win'):
             if IS_PY3K:
-                if isinstance(fd, io.FileIO):
-                    yield fd
-                    return
+                if isinstance(new_fd, io.FileIO):
+                    yield new_fd
+                else:
+                    yield new_fd.read
             else:
-                if isinstance(fd, file):
-                    yield fd
-                    return
-
-        yield fd.read
-        return
-    else:
-        raise TypeError("Can not be coerced to read function")
+                if isinstance(new_fd, file):
+                    yield new_fd
+                else:
+                    yield new_fd.read
 
 
 def _fast_iterparse(fd, buffersize=2 ** 10):


### PR DESCRIPTION
This integrates `astropy.io.vo` to use the new function.

It fixes the following issues with the new function:
- Python 3 compatibility
- Adds a "binary" flag to determine whether the resulting file object should return bytes
- Doesn't close file descriptors that were passed in
