### PR TITLE
Make equivalencies on partial units work.

### DIFF
--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -157,6 +157,9 @@ def test_spectraldensity2():
     # Convert to ergs / s at 10 microns
     assert_allclose(f_lambda.to(u.erg / u.s, 1., equivalencies=u.spectral_density(u.micron, 10.)), 10.)
 
+    # Convert ergs / s to ph / s
+    assert_allclose((u.erg / u.s).to(u.ph / u.s, equivalencies=u.spectral_density(u.micron, 10.)), 5.0341170081942266e+19)
+
 
 def test_units_conversion():
     assert_allclose(u.kpc.to(u.Mpc), 0.001)


### PR DESCRIPTION
This is to address the shortcoming of the equivalencies mentioned in https://github.com/astropy/astropy/pull/692:

```
Before we implement any more, I'd like to understand why defining ergs <-> photon does not allow ergs / s <-> photon / s to work. 
```

This factors the equivalencies out as partial units instead.

This also makes `dimensionless_constant` a private method -- it should have been all along.

I don't know whether this should be put in 0.2 as a bugfix (probably), but I've made it against https://github.com/astropy/astropy/pull/692 because there are some good examples to test there.
