### PR TITLE
fix for failing sphinx build

### DIFF
--- a/astropy/sphinx/ext/automodapi.py
+++ b/astropy/sphinx/ext/automodapi.py
@@ -229,7 +229,7 @@ def automodapi_replace(sourcestr, app, dotoctree=True, docname=None,
             elif toinclude:
                 skips_or_includes = ':include: ' + ','.join(toinclude)
             else:
-                skips_or_includes = None
+                skips_or_includes = ''
 
             if hasfuncs:
                 newstrs.append(automod_templ_funcs.format(modname=modnm,


### PR DESCRIPTION
The source of this was setting a variable to None that was later used in a `str.format` call.  `None` renders to "None" instead of "", so that was confusing sphinx.  Changing it to the empty string solves this.
