### PR TITLE
Gets the tests at least passing with Quantity as an ndarray subclass

### DIFF
--- a/astropy/constants/constant.py
+++ b/astropy/constants/constant.py
@@ -57,7 +57,10 @@ class ConstantMeta(type):
 
         # The wrapper applies to so many of the __ methods that it's easier to
         # just exclude the ones it doesn't apply to
-        exclude = set(['__init__', '__str__', '__repr__'])
+        exclude = set(['__new__', '__array_finalize__', '__dir__',
+                       '__getattr__', '__init__', '__str__', '__repr__',
+                       '__hash__', '__iter__', '__getitem__', '__len__',
+                       '__nonzero__'])
         for attr, value in vars(Quantity).items():
             if (isinstance(value, types.FunctionType) and
                     attr.startswith('__') and attr.endswith('__') and
@@ -87,7 +90,7 @@ class Constant(Quantity):
             warnings.warn('Constant {0!r} is already has a definition in the '
                           '{1!r} system'.format(name, system))
 
-        inst = super(Constant, cls).__new__(cls)
+        inst = super(Constant, cls).__new__(cls, value)
 
         for c in instances.values():
             if system is not None and not hasattr(c.__class__, system):

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -19,6 +19,7 @@ import numpy as np
 from .core import Unit, UnitBase, CompositeUnit, UnitsException
 from .. import log
 from ..config import ConfigurationItem
+from ..utils import lazyproperty
 from ..utils.compat.misc import override__dir__
 
 
@@ -53,12 +54,8 @@ def _validate_value(value):
 
     from ..utils.misc import isiterable
 
-    if isinstance(value, (numbers.Number, np.number)):
-        value_obj = value
-    elif isiterable(value):
-        value_obj = np.array(value, copy=True)
-    elif isinstance(value, np.ndarray):
-        # A length-0 numpy array (i.e. numpy scalar) which we accept as-is
+    if (isinstance(value, (numbers.Number, np.number, np.ndarray)) or
+            isiterable(value)):
         value_obj = np.array(value, copy=True)
     else:
         raise TypeError("The value must be a valid Python or Numpy numeric "
@@ -102,14 +99,23 @@ class Quantity(np.ndarray):
         from ..utils.misc import isiterable
 
         if isinstance(value, Quantity):
-            _value = _validate_value(value.to(_unit).value)
+            _value = _validate_value(value.to(unit).value)
         elif isiterable(value) and all([isinstance(v, Quantity) for v in value]):
-            _value = _validate_value([q.to(_unit).value for q in value])
+            _value = _validate_value([q.to(unit).value for q in value])
         else:
             _value = _validate_value(value)
 
-        self = np.asarray(_value, dtype=dtype).view(cls)
-        self._unit = Unit(unit)
+        if dtype is not None and dtype != _value.dtype:
+            _value = _value.astype(dtype)
+        else:
+            dtype = _value.dtype
+
+        self = super(Quantity, cls).__new__(cls, _value.shape, dtype=dtype,
+                                            buffer=_value.data)
+        if unit is None:
+            self._unit = Unit(1)
+        else:
+            self._unit = Unit(unit)
         self._equivalencies = Unit._normalize_equivalencies(equivalencies)
 
         return self
@@ -119,9 +125,6 @@ class Quantity(np.ndarray):
             return
         if isinstance(obj, Quantity):
             self._unit = obj._unit
-
-    def __array_wrap__(self, out_arr, context=None):
-        return np.ndarray.__array_wrap__(self, out_arr, context)
 
     def to(self, unit, equivalencies=None):
         """ Returns a new `Quantity` object with the specified units.
@@ -149,7 +152,10 @@ class Quantity(np.ndarray):
     def value(self):
         """ The numerical value of this quantity. """
 
-        return self.view(np.ndarray)
+        if not self.shape:
+            return self.item()
+        else:
+            return self.view(np.ndarray)
 
     @property
     def unit(self):
@@ -191,7 +197,7 @@ class Quantity(np.ndarray):
         cgs_unit = self.unit.to_system(cgs)[0]
         return Quantity(self.value * cgs_unit.scale, cgs_unit / cgs_unit.scale)
 
-    @property
+    @lazyproperty
     def isscalar(self):
         """
         True if the `value` of this quantity is a scalar, or False if it

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -49,9 +49,11 @@ class TestQuantityCreation(object):
         # create objects using the Quantity constructor:
         q1 = u.Quantity(11.412, unit=u.meter)
         q2 = u.Quantity(21.52, "cm")
+        q3 = u.Quantity(11.412)
 
-        with pytest.raises(TypeError):
-            q3 = u.Quantity(11.412)
+        # By default quantities that don't specify a unit are unscaled
+        # dimensionless
+        assert q3.unit == u.Unit(1)
 
     def test_3(self):
         # with pytest.raises(u.UnitsException):
@@ -404,14 +406,13 @@ def test_arrays():
         qsecnotarray[0]
 
     qseclen0array = u.Quantity(np.array(10), u.second)
-    # 0d numpy array should act basically like a scalar, but still keep its
-    # identity as a numpy array
+    # 0d numpy array should act basically like a scalar
     assert qseclen0array.isscalar
     with pytest.raises(TypeError):
         len(qseclen0array)
     with pytest.raises(TypeError):
         qseclen0array[0]
-    assert isinstance(qseclen0array.value, np.ndarray)
+    assert isinstance(qseclen0array.value, int)
 
     # can also create from lists, will auto-convert to arrays
     qsec = u.Quantity(range(10), u.second)


### PR DESCRIPTION
This required two changes in the existing behavior of the class (both of which could
be worked around, but for now these changes were the easiest way to get things
working):
1. Quantity.value always returns a Python type (such as `int` or `float`) for
   scalar quantities, even if the underlying object is a Numpy scalar array.
2. Quantity instances have a default unit of unscaled_dimensionless (previously
   it was erroneous to instantiate a Quantity without specifying a unit).

If either of those behaviors are undesirable I can find further workarounds.

There are also two other problems so far with the approach: `dir()` is made pretty unhelpful due to all the methods and attributes exposed from numpy arrays.  Some of those may be worth exposing (especially for array Quantities--not so much for scalars).  We might be able to patch that up a bit at least in IPython by further overriding `__dir__`.

The other is that a lot of the methods exposed have strange behavior on scalars.  For example:

```
In [3]: q = Quantity(2, 'm')

In [4]: q.std()
←[0;31mERROR←[0m: TypeError: Object of type '<type 'numpy.float64'>' cannot be subtracted from a Quantity object. Subtraction is only supported between Quantity objects with compatible units. [astropy.units.quantity]
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-4-4a1c6bbc40e5> in <module>()
----> 1 q.std()

c:\Python27\lib\site-packages\numpy-1.7.0-py2.7-win32.egg\numpy\core\_methods.pyc in _std(a, axis, dtype, out, ddof, keepdims)
    100 def _std(a, axis=None, dtype=None, out=None, ddof=0, keepdims=False):
    101     ret = _var(a, axis=axis, dtype=dtype, out=out, ddof=ddof,
--> 102                keepdims=keepdims)
    103
    104     if isinstance(ret, mu.ndarray):

c:\Python27\lib\site-packages\numpy-1.7.0-py2.7-win32.egg\numpy\core\_methods.pyc in _var(a, axis, dtype, out, ddof, keepdims)
     75
     76     # arr - arrmean
---> 77     x = arr - arrmean
     78
     79     # (arr - arrmean) ** 2

C:\MinGW\msys\1.0\home\embray\src\astropy\astropy\units\quantity.pyc in __sub__(self, other)
    298                 "Object of type '{0}' cannot be subtracted from a Quantity "
    299                 "object. Subtraction is only supported between Quantity "
--> 300                 "objects with compatible units.".format(other.__class__))
    301
    302     def __mul__(self, other):

TypeError: Object of type '<type 'numpy.float64'>' cannot be subtracted from a Quantity object. Subtraction is only supported between Quantity objects with compatible units.
```

Obviously `std()` for a scalar shouldn't work, and on Numpy it causes an exception too, albeit a different one.  In both cases the exception raised is not very clear as far what the actual problem is.
