### PR TITLE
Simplify creating GUI consent dialogs

### DIFF
--- a/astropy/vo/samp/hub.py
+++ b/astropy/vo/samp/hub.py
@@ -1316,17 +1316,27 @@ class WebProfileDialog(object):
 
     The concrete class must:
 
-        1) Poll `handle_queue` periodically, using the timer services of the
-           GUI's event loop.  The function passed to `handle_queue` will be
-           called when a request requires authorization.  This function will
-           be given the arguments `samp_name` (the name of the request), and
-           `request` (the
+        1) Poll `handle_queue` periodically, using the timer services
+           of the GUI's event loop.  This function will call
+           `self.show_dialog` when a request requires authorization.
+           `self.show_dialog` will be given the arguments:
+
+              - ``samp_name``: The name of the application making the request.
+
+              - ``details``: A dictionary of details about the client
+                making the request.
+
+              - ``client``: A hostname, port pair containing the client
+                address.
+
+              - ``origin``: A string containing the origin of the
+                request.
 
         2) Call `consent` or `reject` based on the user's response to
            the dialog.
     """
 
-    def handle_queue(self, show_dialog):
+    def handle_queue(self):
         try:
             request = self.queue_request.get_nowait()
         except queue.Empty:  # queue is set but empty

--- a/docs/vo/samp/advanced_embed_samp_hub.rst
+++ b/docs/vo/samp/advanced_embed_samp_hub.rst
@@ -88,7 +88,7 @@ for web SAMP connections and opens the appropriate dialog::
             self.wait_for_dialog()
 
         def wait_for_dialog(self):
-            self.handle_queue(self.show_dialog)
+            self.handle_queue()
             self.root.after(100, self.wait_for_dialog)
 
         def show_dialog(self, samp_name, details, client, origin):


### PR DESCRIPTION
This moves all of the Queue handling to the base class.  Not only is it simpler to for the end user, it allows us to change the protocol that's sent along the queues in the future if we need to.

I also changed this to use `tkMessageBox.askyesno` instead of building a whole dialog from scratch with the accompanying button callbacks etc., which I think makes it a lot clearer what's going on.  In the real world, using a canned dialog won't always work, but for the simple minimal example, I think this might be better, IMHO.

I'm not entirely sure where this base class should live -- feel free to move it / put it in another namespace, etc.
