### PR TITLE
Docs/smart resolve private things

### DIFF
--- a/astropy/sphinx/ext/smart_resolver.py
+++ b/astropy/sphinx/ext/smart_resolver.py
@@ -35,8 +35,18 @@ def missing_reference_handler(app, env, node, contnode):
         reftarget = node['reftarget']
         suffix = ''
         if reftarget not in mapping:
-            if reftype in ('obj', 'meth') and '.' in reftarget:
+            if '.' in reftarget:
                 front, suffix = reftarget.rsplit('.', 1)
+            else:
+                suffix = reftarget
+
+            if suffix.startswith('_') and not suffix.startswith('__'):
+                # If this is a reference to a hidden class or method,
+                # we can't link to it, but we don't want to have a
+                # nitpick warning.
+                return node[0].deepcopy()
+
+            if reftype in ('obj', 'meth') and '.' in reftarget:
                 if front in mapping:
                     reftarget = front
                     suffix = '.' + suffix

--- a/docs/nitpick-exceptions
+++ b/docs/nitpick-exceptions
@@ -2,25 +2,14 @@
 py:class astropy.io.votable.tree.Element
 py:class astropy.io.votable.tree.SimpleElement
 py:class astropy.io.votable.tree.SimpleElementWithContent
-py:class astropy.io.votable.tree._DescriptionProperty
-py:class astropy.io.votable.tree._IDProperty
-py:class astropy.io.votable.tree._NameProperty
-py:class astropy.io.votable.tree._UcdProperty
-py:class astropy.io.votable.tree._UtypeProperty
-py:class astropy.io.votable.tree._XtypeProperty
 
 # astropy.modeling
 py:class astropy.modeling.projections.Zenithal
 py:class astropy.modeling.projections.Cylindrical
-py:class astropy.modeling.core._CompositeModel
 py:class astropy.modeling.polynomial.PolynomialBase
 py:class astropy.modeling.rotations.EulerAngleRotation
 
 # astropy.io.fits
-py:class astropy.io.fits.diff._BaseDiff
-py:class astropy.io.fits.verify._Verify
-py:class astropy.io.fits.hdu.image._ImageBaseHDU
-py:class astropy.io.fits.hdu.table._TableLikeHDU
 py:class astropy.io.fits.hdu.base.ExtensionHDU
 
 # astropy.table


### PR DESCRIPTION
When referencing a private class or method, we should just assume it's not going to be documented, and not have a nitpicky warning about it.
