### PR TITLE
Convert string-like column to numpy string type in from_pandas()

### DIFF
--- a/docs/table/pandas.rst
+++ b/docs/table/pandas.rst
@@ -35,13 +35,13 @@ It is also possible to create a table from a `DataFrame`_::
     >>> t2 = Table.from_pandas(df)
     >>> t2
     <Table masked=False length=4>
-      a     b   
-    int64 object
-    ----- ------
-        1      a
-        2      b
-        3      c
-        4      d
+      a      b
+    int64 string8
+    ----- -------
+        1       a
+        2       b
+        3       c
+        4       d
         
 The conversions to/from pandas are subject to the following caveats:
 


### PR DESCRIPTION
This passes tests locally for py 2.7 and 3.4.

This potentially slows things down for object columns that are not string columns in disguise, but I think that case is sufficiently in the corner to not worry about.  In theory we could add a kwarg to explicitly control this, but I think simple is better.

The only extraneous changes were removing the import of pandas DataFrame from each test case.  Was there a reason for that?  If somehow the tests manage to run despite the `skipif` then it will still give an `ImportError`.