### PR TITLE
Update whatsnew for 1.1 with stats

### DIFF
--- a/docs/whatsnew/1.1.rst
+++ b/docs/whatsnew/1.1.rst
@@ -26,9 +26,9 @@ In addition to these major changes, Astropy 1.1 includes a large number of
 smaller improvements and bug fixes, which are described in the
 :ref:`changelog`. By the numbers:
 
-* ??? issues have been closed since v1.0
-* ??? pull requests have been merged since v1.0
-* ??? distinct people have contributed code
+* 785 issues have been closed since v1.0
+* 459 pull requests have been merged since v1.0
+* 159 distinct people have contributed code
 
 .. _whatsnew-1.1-coords:
 

--- a/docs/whatsnew/1.1.rst
+++ b/docs/whatsnew/1.1.rst
@@ -170,6 +170,8 @@ units such as magnitudes, decibels, and dex::
     >>> logg.physical
     <Quantity 100000.0 cm / s2>
 
+For more information, see :ref:`logarithmic_units`.
+
 In addition, the following units have been added:
 
 * Furlongs (``imperial.furlong``)
@@ -181,7 +183,6 @@ Finally, quantity arrays can now be used in Matplotlib, which will recognize
 the unit and plot the quantities correctly (see :ref:`plotting-quantities`
 for more details on how to enable this).
 
-For more information, see :ref:`logarithmic_units`.
 
 .. _whatsnew-1.1-cosmo:
 


### PR DESCRIPTION
This updates the what's new section with the latest stats.  It might change by one or two before release, but as of right now this is correct.