### PR TITLE
Add support for plt.grid-like interface

### DIFF
--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -445,8 +445,9 @@ class WCSAxes(Axes):
         axis = kwargs.pop('axis', 'both')
         if axis != 'both':
             raise ValueError('WCSAxes can only draw gridlines on both axes')
-        if 'b' in kwargs:
-            draw_grid = kwargs.pop('b')
+        b = kwargs.pop('b', True)
+        if not b:
+            raise ValueError('WCSAxes cannot have grids removed once they are on')
 
         if draw_grid and hasattr(self, 'coords'):
             self.coords.grid(draw_grid=draw_grid, **kwargs)

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -437,6 +437,17 @@ class WCSAxes(Axes):
         draw_grid : bool
             Whether to show the gridlines
         """
+        # these kwargs mock up the interface to plt.grid, allowing it to be used
+        # to set the grid
+        which = kwargs.pop('which', 'major')
+        if which != 'major':
+            raise ValueError('WCSAxes can only draw major gridlines')
+        axis = kwargs.pop('axis', 'both')
+        if axis != 'both':
+            raise ValueError('WCSAxes can only draw gridlines on both axes')
+        if 'b' in kwargs:
+            draw_grid = kwargs.pop('b')
+
         if draw_grid and hasattr(self, 'coords'):
             self.coords.grid(draw_grid=draw_grid, **kwargs)
 


### PR DESCRIPTION
This minor PR adjusts the `grid` function to "accept" (basically just ignore as long as they aren't invalid) the arguments the `pyplot.grid` function takes.  This allows a user to just do ``plt.grid(True)`` in a wcsaxes, and have it work.