### PR TITLE
Unit aware evaluate

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -659,7 +659,9 @@ class Model(object):
     _n_models = 1
 
     # Enforce strict units on inputs to evaluate
-    _strict_unit_inputs = False
+    _strict_input_units = False
+    # Enforce units on output of evaluate
+    _strict_return_units = False
 
     def __init__(self, *args, **kwargs):
         super(Model, self).__init__()
@@ -700,6 +702,9 @@ class Model(object):
             outputs = (outputs,)
 
         outputs = self.prepare_outputs(format_info, *outputs, **kwargs)
+
+        if self.return_units and self.strict_return_units:
+            outputs = [Quantity(out, self.return_units) for out in outputs]
 
         if self.n_outputs == 1:
             return outputs[0]
@@ -792,19 +797,34 @@ class Model(object):
         return self._parameters[start:stop]
 
     @property
-    def strict_unit_inputs(self):
+    def strict_input_units(self):
         """
-        If ``strict_unit_inputs`` is true, inputs to ``evaluate`` will be
+        If ``strict_input_units`` is `True`, inputs to ``evaluate`` will be
         parsed with the units specified in ``input_units`` rather than in
         compatible units. (This does not apply to parameters).
         """
-        return self._strict_unit_inputs
+        return self._strict_input_units
 
-    @strict_unit_inputs.setter
-    def strict_unit_inputs(self, val):
+    @strict_input_units.setter
+    def strict_input_units(self, val):
         if not isinstance(val, bool):
-            raise ValueError("strict_unit_inputs must be Boolean")
-        self._strict_unit_inputs = val
+            raise ValueError("strict_input_units must be Boolean")
+        self._strict_input_units = val
+
+    @property
+    def strict_return_units(self):
+        """
+        If ``strict_return_units`` is `True`, the return value of ``evaluate`` will be
+        converted to a `~astropy.units.Quantity` object with the return units.
+        """
+        return self._strict_return_units
+
+    @strict_return_units.setter
+    def strict_return_units(self, val):
+        if not isinstance(val, bool):
+            raise ValueError("strict_input_units must be Boolean")
+        self._strict_return_units = val
+
 
     @parameters.setter
     def parameters(self, value):
@@ -1232,10 +1252,19 @@ class Model(object):
     def input_units(self):
         if hasattr(self.evaluate, '__annotations__'):
             annotations = self.evaluate.__annotations__.copy()
-            annotations.pop('return')
+            annotations.pop('return', None)
             if annotations:
                 # If there are not annotations for all inputs this will error.
                 return tuple([self.evaluate.__annotations__[name] for name in self.inputs])
+        else:
+            # None means any unit is accepted
+            return None
+
+    @property
+    def return_units(self):
+        if hasattr(self.evaluate, '__annotations__'):
+            return_units = self.evaluate.__annotations__.get('return', None)
+            return return_units
         else:
             # None means any unit is accepted
             return None
@@ -1287,7 +1316,7 @@ class Model(object):
             for i in range(len(inputs)):
                 if isinstance(inputs[i], Quantity):
                     if inputs[i].unit.is_equivalent(input_units[i], equivalencies=equivalencies):
-                        if equivalencies is not None or self.strict_unit_inputs:
+                        if equivalencies is not None or self.strict_input_units:
                             inputs[i] = inputs[i].to(input_units[i], equivalencies=equivalencies)
                     else:
                         if input_units[i] is dimensionless_unscaled:

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -1255,7 +1255,7 @@ class Model(object):
             annotations.pop('return', None)
             if annotations:
                 # If there are not annotations for all inputs this will error.
-                return tuple([self.evaluate.__annotations__[name] for name in self.inputs])
+                return tuple([annotations[name] for name in self.inputs])
         else:
             # None means any unit is accepted
             return None

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -659,9 +659,7 @@ class Model(object):
     _n_models = 1
 
     # Enforce strict units on inputs to evaluate
-    strict_input_units = False
-    # Enforce units on output of evaluate
-    strict_return_units = False
+    input_units_strict = False
 
     def __init__(self, *args, **kwargs):
         super(Model, self).__init__()
@@ -703,13 +701,15 @@ class Model(object):
 
         outputs = self.prepare_outputs(format_info, *outputs, **kwargs)
 
-        if self.return_units and self.strict_return_units:
-            if not isiterable(self.return_units):
-                return_units = [self.return_units] * self.n_outputs
+        if self.return_units:
+            # We allow a non-iterable unit only if there is one output
+            if self.n_outputs == 1 and not isiterable(self.return_units):
+                return_units = (self.return_units,)
             else:
                 return_units = self.return_units
 
-            outputs = [Quantity(out, unit, subok=True) for out, unit in zip(outputs, return_units)]
+            outputs = tuple([Quantity(out, unit, subok=True)
+                             for out, unit in zip(outputs, return_units)])
 
         if self.n_outputs == 1:
             return outputs[0]
@@ -1238,11 +1238,7 @@ class Model(object):
     @property
     def return_units(self):
         if hasattr(self.evaluate, '__annotations__'):
-            return_units = self.evaluate.__annotations__.get('return', None)
-            if isiterable(return_units):
-                return return_units
-            else:
-                return tuple([return_units] * self.n_outputs)
+            return self.evaluate.__annotations__.get('return', None)
         else:
             # None means any unit is accepted
             return None
@@ -1294,7 +1290,7 @@ class Model(object):
             for i in range(len(inputs)):
                 if isinstance(inputs[i], Quantity):
                     if inputs[i].unit.is_equivalent(input_units[i], equivalencies=equivalencies):
-                        if equivalencies is not None or self.strict_input_units:
+                        if equivalencies is not None or self.input_units_strict:
                             inputs[i] = inputs[i].to(input_units[i], equivalencies=equivalencies)
                     else:
                         if input_units[i] is dimensionless_unscaled:

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -704,7 +704,12 @@ class Model(object):
         outputs = self.prepare_outputs(format_info, *outputs, **kwargs)
 
         if self.return_units and self.strict_return_units:
-            outputs = [Quantity(out, self.return_units) for out in outputs]
+            if not isiterable(self.return_units):
+                return_units = [self.return_units] * self.n_outputs
+            else:
+                return_units = self.return_units
+
+            outputs = [Quantity(out, unit, subok=True) for out, unit in zip(outputs, return_units)]
 
         if self.n_outputs == 1:
             return outputs[0]
@@ -1264,7 +1269,10 @@ class Model(object):
     def return_units(self):
         if hasattr(self.evaluate, '__annotations__'):
             return_units = self.evaluate.__annotations__.get('return', None)
-            return return_units
+            if isiterable(return_units):
+                return return_units
+            else:
+                return tuple([return_units] * self.n_outputs)
         else:
             # None means any unit is accepted
             return None

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -1230,8 +1230,15 @@ class Model(object):
 
     @property
     def input_units(self):
-        # None means any unit is accepted
-        return None
+        if hasattr(self.evaluate, '__annotations__'):
+            annotations = self.evaluate.__annotations__.copy()
+            annotations.pop('return')
+            if annotations:
+                # If there are not annotations for all inputs this will error.
+                return tuple([self.evaluate.__annotations__[name] for name in self.inputs])
+        else:
+            # None means any unit is accepted
+            return None
 
     @property
     def _supports_unit_fitting(self):

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -659,9 +659,9 @@ class Model(object):
     _n_models = 1
 
     # Enforce strict units on inputs to evaluate
-    _strict_input_units = False
+    strict_input_units = False
     # Enforce units on output of evaluate
-    _strict_return_units = False
+    strict_return_units = False
 
     def __init__(self, *args, **kwargs):
         super(Model, self).__init__()
@@ -800,36 +800,6 @@ class Model(object):
         stop = self._param_metrics[self.param_names[-1]]['slice'].stop
 
         return self._parameters[start:stop]
-
-    @property
-    def strict_input_units(self):
-        """
-        If ``strict_input_units`` is `True`, inputs to ``evaluate`` will be
-        parsed with the units specified in ``input_units`` rather than in
-        compatible units. (This does not apply to parameters).
-        """
-        return self._strict_input_units
-
-    @strict_input_units.setter
-    def strict_input_units(self, val):
-        if not isinstance(val, bool):
-            raise ValueError("strict_input_units must be Boolean")
-        self._strict_input_units = val
-
-    @property
-    def strict_return_units(self):
-        """
-        If ``strict_return_units`` is `True`, the return value of ``evaluate`` will be
-        converted to a `~astropy.units.Quantity` object with the return units.
-        """
-        return self._strict_return_units
-
-    @strict_return_units.setter
-    def strict_return_units(self, val):
-        if not isinstance(val, bool):
-            raise ValueError("strict_input_units must be Boolean")
-        self._strict_return_units = val
-
 
     @parameters.setter
     def parameters(self, value):

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -38,7 +38,7 @@ from ..units import Quantity, UnitBase, UnitsError, dimensionless_unscaled
 from ..units.utils import quantity_asanyarray
 from ..utils import (sharedmethod, find_current_module,
                      InheritDocstrings, OrderedDescriptorContainer,
-                     check_broadcast, IncompatibleShapeError)
+                     check_broadcast, IncompatibleShapeError, isiterable)
 from ..utils.codegen import make_function_with_signature
 from ..utils.compat import suppress
 from ..utils.compat.funcsigs import signature
@@ -1253,6 +1253,10 @@ class Model(object):
         # Check that the units are correct, if applicable
 
         if self.input_units is not None:
+            if isiterable(self.input_units):
+                input_units = self.input_units
+                if len(input_units) != len(inputs):
+                    raise ValueError("Input units is not the same length as inputs")
             if isinstance(self.input_units, UnitBase):
                 input_units = (self.input_units,) * len(inputs)
             for i in range(len(inputs)):

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -660,6 +660,8 @@ class Model(object):
 
     # Enforce strict units on inputs to evaluate
     input_units_strict = False
+    # Allow dimensionless input (and corresponding output)
+    input_units_allow_dimensionless = True
 
     def __init__(self, *args, **kwargs):
         super(Model, self).__init__()
@@ -691,6 +693,7 @@ class Model(object):
         """
 
         inputs, format_info = self.prepare_inputs(*inputs, **kwargs)
+        inputs_are_quantity = all([isinstance(i, Quantity) for i in inputs])
 
         parameters = self._param_sets(raw=True, units=True)
 
@@ -701,7 +704,7 @@ class Model(object):
 
         outputs = self.prepare_outputs(format_info, *outputs, **kwargs)
 
-        if self.return_units:
+        if self.return_units and inputs_are_quantity:
             # We allow a non-iterable unit only if there is one output
             if self.n_outputs == 1 and not isiterable(self.return_units):
                 return_units = (self.return_units,)
@@ -1281,12 +1284,15 @@ class Model(object):
         # Check that the units are correct, if applicable
 
         if self.input_units is not None:
-            if isiterable(self.input_units):
+            if self.n_inputs == 1 and not isiterable(self.return_units):
+                input_units = (self.input_units,)
+
+            elif len(self.input_units) != self.n_inputs:
+                raise ValueError("Number of input units must match number of inputs")
+
+            else:
                 input_units = self.input_units
-                if len(input_units) != len(inputs):
-                    raise ValueError("Input units is not the same length as inputs")
-            if isinstance(self.input_units, UnitBase):
-                input_units = (self.input_units,) * len(inputs)
+
             for i in range(len(inputs)):
                 if isinstance(inputs[i], Quantity):
                     if inputs[i].unit.is_equivalent(input_units[i], equivalencies=equivalencies):
@@ -1308,7 +1314,8 @@ class Model(object):
                                                                 input_units[i],
                                                                 input_units[i].physical_type))
                 else:
-                    if input_units[i] is not dimensionless_unscaled:
+                    if (not self.input_units_allow_dimensionless and
+                        input_units[i] is not dimensionless_unscaled):
                         if np.any(inputs[i] != 0):
                             raise UnitsError("Units of input '{0}', (dimensionless), could not be "
                                              "converted to required input units of "

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -658,6 +658,9 @@ class Model(object):
     # model hasn't completed initialization yet
     _n_models = 1
 
+    # Enforce strict units on inputs to evaluate
+    _strict_unit_inputs = False
+
     def __init__(self, *args, **kwargs):
         super(Model, self).__init__()
         meta = kwargs.pop('meta', None)
@@ -787,6 +790,21 @@ class Model(object):
         stop = self._param_metrics[self.param_names[-1]]['slice'].stop
 
         return self._parameters[start:stop]
+
+    @property
+    def strict_unit_inputs(self):
+        """
+        If ``strict_unit_inputs`` is true, inputs to ``evaluate`` will be
+        parsed with the units specified in ``input_units`` rather than in
+        compatible units. (This does not apply to parameters).
+        """
+        return self._strict_unit_inputs
+
+    @strict_unit_inputs.setter
+    def strict_unit_inputs(self, val):
+        if not isinstance(val, bool):
+            raise ValueError("strict_unit_inputs must be Boolean")
+        self._strict_unit_inputs = val
 
     @parameters.setter
     def parameters(self, value):
@@ -1262,15 +1280,15 @@ class Model(object):
             for i in range(len(inputs)):
                 if isinstance(inputs[i], Quantity):
                     if inputs[i].unit.is_equivalent(input_units[i], equivalencies=equivalencies):
-                        if equivalencies is not None:
+                        if equivalencies is not None or self.strict_unit_inputs:
                             inputs[i] = inputs[i].to(input_units[i], equivalencies=equivalencies)
                     else:
                         if input_units[i] is dimensionless_unscaled:
                             raise UnitsError("Units of input '{0}', {1} ({2}), could not be "
                                              "converted to required dimensionless "
                                              "input".format(self.inputs[i],
-                                                                inputs[i].unit,
-                                                                inputs[i].unit.physical_type))
+                                                            inputs[i].unit,
+                                                            inputs[i].unit.physical_type))
                         else:
                             raise UnitsError("Units of input '{0}', {1} ({2}), could not be "
                                              "converted to required input units of "
@@ -1284,7 +1302,8 @@ class Model(object):
                         if np.any(inputs[i] != 0):
                             raise UnitsError("Units of input '{0}', (dimensionless), could not be "
                                              "converted to required input units of "
-                                             "{1} ({2})".format(self.inputs[i], input_units[i], input_units[i].physical_type))
+                                             "{1} ({2})".format(self.inputs[i], input_units[i],
+                                                                input_units[i].physical_type))
 
         # The input formatting required for single models versus a multiple
         # model set are different enough that they've been split into separate

--- a/astropy/modeling/projections.py
+++ b/astropy/modeling/projections.py
@@ -107,17 +107,6 @@ class Projection(Model):
     # the radius of the projection sphere, by which x,y are scaled
     r0 = 180 / np.pi
 
-    _strict_input_units = True
-    _strict_return_units = True
-
-    @property
-    def input_units(self):
-        return tuple([u.deg] * self.n_inputs)
-
-    @property
-    def return_units(self):
-        return u.deg
-
     @abc.abstractproperty
     def inverse(self):
         """
@@ -131,12 +120,32 @@ class Pix2SkyProjection(Projection):
     inputs = ('x', 'y')
     outputs = ('phi', 'theta')
 
+    input_units_strict = True
+
+    @property
+    def input_units(self):
+        return [u.pixel] * self.n_inputs
+
+    @property
+    def return_units(self):
+        return [u.deg] * self.n_outputs
+
 
 class Sky2PixProjection(Projection):
     """Base class for all Sky2Pix projections."""
 
     inputs = ('phi', 'theta')
     outputs = ('x', 'y')
+
+    input_units_strict = True
+
+    @property
+    def input_units(self):
+        return [u.deg] * self.n_inputs
+
+    @property
+    def return_units(self):
+        return [u.pixel] * self.n_outputs
 
 
 class Zenithal(Projection):

--- a/astropy/modeling/projections.py
+++ b/astropy/modeling/projections.py
@@ -24,6 +24,7 @@ from .core import Model
 from .parameters import Parameter, InputParameterError
 
 from ..utils import deprecated
+from .. import units as u
 
 from . import _projections
 
@@ -105,6 +106,17 @@ class Projection(Model):
 
     # the radius of the projection sphere, by which x,y are scaled
     r0 = 180 / np.pi
+
+    _strict_input_units = True
+    _strict_return_units = True
+
+    @property
+    def input_units(self):
+        return tuple([u.deg] * self.n_inputs)
+
+    @property
+    def return_units(self):
+        return u.deg
 
     @abc.abstractproperty
     def inverse(self):


### PR DESCRIPTION
This implements two things:

1. Specifying input units as function annotations on evaluate instead of defining a property.
2. Strict unit enforcement for input and return of evaluate. This means that the model inputs are always converted to input units before calling `evaluate` and the return value is always returned as a quantity with the return units.