### PR TITLE
Add rvcorr example to whatsnew

### DIFF
--- a/docs/coordinates/velocities.rst
+++ b/docs/coordinates/velocities.rst
@@ -290,10 +290,11 @@ on the API and functionality in the frame-level classes before it is adopted in
 Radial Velocity Corrections
 ===========================
 
-Sperately from the above, Astropy supports computing barycentric or heliocentric
-radial velocity corrections.  While in the future this may simply be a
-high-level convenience function using the framework described above, the
-current implementation is independent to ensure sufficient accuracy (see the
+Separately from the above, Astropy supports computing barycentric or
+heliocentric radial velocity corrections.  While in the future this may simply
+be a high-level convenience function using the framework described above, the
+current implementation is independent to ensure sufficient accuracy (see
+:ref:`astropy-coordinates-rv-corrs` and the
 `~astropy.coordinates.SkyCoord.radial_velocity_correction` API docs for
 details).
 

--- a/docs/whatsnew/2.0.rst
+++ b/docs/whatsnew/2.0.rst
@@ -78,7 +78,19 @@ In addition, the :class:`~astropy.coordinates.SkyCoord` class now has a
 `~astropy.coordinates.SkyCoord.radial_velocity_correction` method which can be
 used to compute heliocentric and barycentric corrections for radial velocity
 measurements.  While in the future this may use the mechanisms described above,
-currently it uses a simpler algorithm for numerical stability.
+currently it uses a simpler algorithm for numerical stability. A simple example
+of using this functionality might be::
+
+    >>> from astropy.coordinates import SkyCoord, EarthLocation
+    >>> from astropy.time import Time
+    >>> obstime = Time('2017-2-14')
+    >>> target = SkyCoord.from_name('M31')
+    >>> keck = EarthLocation.of_site('Keck')
+    >>> target.radial_velocity_correction(obstime=obstime, location=keck).to('km/s')
+    <Quantity -22.363056056262263 km / s>
+
+
+
 
 .. _whatsnew-2.0-stats:
 


### PR DESCRIPTION
Just what it says - Although note that it includes a ``:ref:`` that needs astropy/astropy#6337, so to get tests to pass that will need a rebase...