### PR TITLE
add check that input to HighLevelWCS is a low level WCS

### DIFF
--- a/astropy/wcs/wcsapi/high_level_wcs_wrapper.py
+++ b/astropy/wcs/wcsapi/high_level_wcs_wrapper.py
@@ -1,5 +1,7 @@
 from .high_level_api import HighLevelWCSMixin
 
+from . import BaseLowLevelWCS
+
 __all__ = ['HighLevelWCSWrapper']
 
 
@@ -10,6 +12,9 @@ class HighLevelWCSWrapper(HighLevelWCSMixin):
     """
 
     def __init__(self, low_level_wcs):
+        if not isinstance(low_level_wcs, BaseLowLevelWCS):
+            raise TypeError('Input to a HighLevelWCSWrapper must be a low level WCS object')
+
         self._low_level_wcs = low_level_wcs
 
     @property


### PR DESCRIPTION
Inspired by some testing I did where I was confused about what the correct input was for the high level object.

An alternative would be more like duck-typing.  E.g., ``hasattr(wcs, 'pixel_to_world_values`)``... But given how tightly-specified the APIs are here (the the fact that the low level one is an interface class), I think the `isinstance` might actually be warranted.