### PR TITLE
WCS Axes bug fix for APE14

### DIFF
--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -327,7 +327,11 @@ class WCSAxes(Axes):
             # by hand. For example if the user sets a celestial WCS by hand and
             # forgets to set the units, WCS.wcs.set() will do this.
             if wcs is not None:
-                wcs.wcs.set()
+                # Check if the WCS object is an instance of `astropy.wcs.WCS`
+                # This check is necessary as only `astropy.wcs.WCS` supports
+                # wcs.set() method
+                if isinstance(wcs, WCS):
+                    wcs.wcs.set()
 
             self.wcs = wcs
 
@@ -343,6 +347,7 @@ class WCSAxes(Axes):
             previous_frame = {'path': None}
 
         if self.wcs is not None:
+
             transform, coord_meta = transform_coord_meta_from_wcs(self.wcs, self.frame_class, slices)
 
         self.coords = CoordinatesMap(self,


### PR DESCRIPTION
This PR addresses to solve the bug arising due to using any other `WCS` object other than `astropy.wcs.WCS`.

## Current Issue
If any other `WCS` object having a `_as_mpl_axes` method is used to plot, it raises an error because the following attribute `wcs.set()` is not present. 
For instance, I am using `SlicedLowLevelWCS` which does not have `wcs.set()` attribute, so it raises an error - 
```
~/astropydev_new/astropy/astropy/visualization/wcsaxes/core.py in reset_wcs(self, wcs, slices, transform, coord_meta)
    332                 # wcs.set() method
    333                 if isinstance(wcs, WCS):
--> 334                   wcs.wcs.set()
    335 
    336             self.wcs = wcs

AttributeError: 'SlicedLowLevelWCS' object has no attribute 'set'
```
## Fix
So this PR makes setting the `wcs.set()` attribute optional only for `astropy.wcs.WCS`
```
            if wcs is not None:
                # Check if the WCS object is an instance of `astropy.wcs.WCS`
                # This check is necessary as only `astropy.wcs.WCS` supports
                # wcs.set() method
                if isinstance(wcs, WCS):
                    wcs.wcs.set()
```
##
For more contextual information about the PR, @Cadair can be contacted :stuck_out_tongue: 
Also ping @astrofrog 