### PR TITLE
Fixing of default coord_type of non-scalar axes

### DIFF
--- a/astropy/visualization/wcsaxes/wcsapi.py
+++ b/astropy/visualization/wcsaxes/wcsapi.py
@@ -59,8 +59,10 @@ def transform_coord_meta_from_wcs(wcs, frame_class, aslice=None):
             if "pos.helioprojective.lon" in axis_type:
                 coord_wrap = 180.
                 format_unit = u.arcsec
+                coord_type = "longitude"
             elif "pos.helioprojective.lat" in axis_type:
                 format_unit = u.arcsec
+                coord_type = "latitude"
             elif "pos" in axis_type_split:
                 if "lon" in axis_type_split:
                     coord_type = "longitude"


### PR DESCRIPTION
When we use this branch for plotting APE14 specific `WCS` object, if one/both of the axes are `pos.helioprojective.lon` and `pos.helioprojective.lat` then it raises an error. 
This PR adds a coord_type of both, since default value - `scalar` is being used, which is incorrect.

Ping @astrofrog !