### PR TITLE
Added plotting support for BaseLowLevelWCS

### DIFF
--- a/astropy/wcs/wcsapi/low_level_api.py
+++ b/astropy/wcs/wcsapi/low_level_api.py
@@ -278,6 +278,24 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
         """
         return False
 
+    def _as_mpl_axes(self):
+        """
+        Compatibility hook for Matplotlib and WCSAxes.
+        With this method, one can do:
+            from astropy.wcs import WCS
+            import matplotlib.pyplot as plt
+            wcs = WCS('filename.fits')
+            fig = plt.figure()
+            ax = fig.add_axes([0.15, 0.1, 0.8, 0.8], projection=wcs)
+            ...
+        and this will generate a plot with the correct WCS coordinates on the
+        axes.
+        """
+
+        # Note this method taken from `astropy.wcs.WCS`
+        from astropy.visualization.wcsaxes import WCSAxes
+        return WCSAxes, {'wcs': self}
+
     def __str__(self):
 
         # Overall header


### PR DESCRIPTION
This PR adds the support for plotting for `BaseLowLevelWCS`. Note that plotting is not possible out of the box due to this PR, but it just adds a method `_as_mpl_axes` which is necessary for supporting plotting for `BaseLowLevelWCS`.
##
Supercedes [#PR 8980](https://github.com/astropy/astropy/pull/8980)
Ping @astrofrog 