### PR TITLE
Avoid calling wcsset if the wcsprm is unchanged

### DIFF
--- a/astropy/wcs/include/astropy_wcs/wcslib_wrap.h
+++ b/astropy/wcs/include/astropy_wcs/wcslib_wrap.h
@@ -12,6 +12,8 @@ extern PyTypeObject PyWcsprmType;
 typedef struct {
   PyObject_HEAD
   struct wcsprm x;
+  struct wcsprm x_prev;
+  int x_prev_set;
 } PyWcsprm;
 
 int _setup_wcsprm_type(PyObject* m);


### PR DESCRIPTION
The wcsprm_python2c and wcsprm_c2python calls probably aren't thread-safe but this is already an issue anyway and I have ideas for how to remove the need for them.