### PR TITLE
Added support for 16-bit floating point values in FITS PrimaryHDU and ImageHDU

### DIFF
--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -48,6 +48,7 @@ BITPIX2DTYPE = {
     16: "int16",
     32: "int32",
     64: "int64",
+    -16: "float16",
     -32: "float32",
     -64: "float64",
 }
@@ -62,6 +63,7 @@ DTYPE2BITPIX = {
     "uint32": 32,
     "int64": 64,
     "uint64": 64,
+    "float16": -16,
     "float32": -32,
     "float64": -64,
 }


### PR DESCRIPTION
Just a simple proof of concept for 16-bit floating point support in FITS